### PR TITLE
Don't remove references to a secret when it is deleted

### DIFF
--- a/internal/cert/manager.go
+++ b/internal/cert/manager.go
@@ -395,7 +395,6 @@ func (m *Manager) deleteSecret(s *v1.Secret) bool {
 			log.Error("cannot remove stale TLS certpair", zap.Error(err))
 			continue
 		}
-		m.secretRefs.Delete(s.GetNamespace(), ingressName, s.GetName())
 		changed = true
 		log.Debug("deleted cert pair")
 	}


### PR DESCRIPTION
hal5d tracks which TLS secrets each ingress references. This handles the case in which an ingress is created before the secret(s) it references. If/when the referenced secret(s) are created we know they are associated with an ingress and write them out to disk. Removing a secret should not remove its secret reference - the secret is still referenced by the ingress until the ingress is deleted.

Deleting the secret reference caused a bug in which a secret, once deleted, would not be noticed when it was re-added (until the ingress was re-added too).