### PR TITLE
Emit Kubernetes events when certificates are loaded or unloaded

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: d1ae6e83d3949be80112b349b7bf9eeda57ca8d5ece81b8f82058c85da003d5c
-updated: 2018-03-14T20:39:38.418543-07:00
+hash: c6dbcbd511c8bbb8a245f309ee41d7e24a82b4051cc800e4b3cff537f21255e7
+updated: 2018-03-15T16:39:29.070771-07:00
 imports:
 - name: github.com/alecthomas/template
   version: a0175ee3bccc567396460bf5acd36800cb10c49c
@@ -36,6 +36,10 @@ imports:
   - sortkeys
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
+- name: github.com/golang/groupcache
+  version: 02826c3e79038b59d737d3b1c0a1d937f71a4433
+  subpackages:
+  - lru
 - name: github.com/golang/protobuf
   version: 1643683e1b54a9e88ad26d98f81400c8c9d9f4f9
   subpackages:
@@ -231,15 +235,18 @@ imports:
   - pkg/util/framer
   - pkg/util/intstr
   - pkg/util/json
+  - pkg/util/mergepatch
   - pkg/util/net
   - pkg/util/runtime
   - pkg/util/sets
+  - pkg/util/strategicpatch
   - pkg/util/validation
   - pkg/util/validation/field
   - pkg/util/wait
   - pkg/util/yaml
   - pkg/version
   - pkg/watch
+  - third_party/forked/golang/json
   - third_party/forked/golang/reflect
 - name: k8s.io/client-go
   version: 78700dec6369ba22221b72770783300f143df150
@@ -286,6 +293,7 @@ imports:
   - tools/clientcmd/api/v1
   - tools/metrics
   - tools/pager
+  - tools/record
   - tools/reference
   - transport
   - util/buffer

--- a/glide.yaml
+++ b/glide.yaml
@@ -17,6 +17,7 @@ import:
 - package: k8s.io/apimachinery
   subpackages:
   - pkg/fields
+  - pkg/runtime
 - package: k8s.io/client-go
   version: v6.0.0
   subpackages:
@@ -25,6 +26,7 @@ import:
   - tools/cache
   - tools/clientcmd
   - tools/clientcmd/api
+  - tools/record
 - package: github.com/prometheus/client_golang
   version: v0.9.0-pre1
 - package: github.com/julienschmidt/httprouter

--- a/internal/cert/manager.go
+++ b/internal/cert/manager.go
@@ -278,13 +278,13 @@ func (m *Manager) upsertIngress(i *v1beta1.Ingress) bool { // nolint:gocyclo
 		cert, ok := s.Data[v1.TLSCertKey]
 		if !ok {
 			log.Info("missing certificate", zap.String("secret key", v1.TLSCertKey))
-			m.recorder.NewInvalid(i.GetNamespace(), i.GetName(), s.GetName())
+			m.recorder.NewInvalidSecret(i.GetNamespace(), i.GetName(), s.GetName())
 			continue
 		}
 		key, ok := s.Data[v1.TLSPrivateKeyKey]
 		if !ok {
 			log.Info("missing private key", zap.String("secret key", v1.TLSPrivateKeyKey))
-			m.recorder.NewInvalid(i.GetNamespace(), i.GetName(), s.GetName())
+			m.recorder.NewInvalidSecret(i.GetNamespace(), i.GetName(), s.GetName())
 			continue
 		}
 
@@ -404,13 +404,13 @@ func (m *Manager) upsertSecret(s *v1.Secret) bool {
 		cert, ok := s.Data[v1.TLSCertKey]
 		if !ok {
 			m.log.Info("missing TLS certificate", zap.String("secret key", v1.TLSCertKey))
-			m.recorder.NewInvalid(s.GetNamespace(), ingressName, s.GetName())
+			m.recorder.NewInvalidSecret(s.GetNamespace(), ingressName, s.GetName())
 			continue
 		}
 		key, ok := s.Data[v1.TLSPrivateKeyKey]
 		if !ok {
 			m.log.Info("missing TLS private key", zap.String("secret key", v1.TLSPrivateKeyKey))
-			m.recorder.NewInvalid(s.GetNamespace(), ingressName, s.GetName())
+			m.recorder.NewInvalidSecret(s.GetNamespace(), ingressName, s.GetName())
 			continue
 		}
 

--- a/internal/cert/manager.go
+++ b/internal/cert/manager.go
@@ -278,11 +278,13 @@ func (m *Manager) upsertIngress(i *v1beta1.Ingress) bool { // nolint:gocyclo
 		cert, ok := s.Data[v1.TLSCertKey]
 		if !ok {
 			log.Info("missing certificate", zap.String("secret key", v1.TLSCertKey))
+			m.recorder.NewInvalid(i.GetNamespace(), i.GetName(), s.GetName())
 			continue
 		}
 		key, ok := s.Data[v1.TLSPrivateKeyKey]
 		if !ok {
 			log.Info("missing private key", zap.String("secret key", v1.TLSPrivateKeyKey))
+			m.recorder.NewInvalid(i.GetNamespace(), i.GetName(), s.GetName())
 			continue
 		}
 
@@ -402,11 +404,13 @@ func (m *Manager) upsertSecret(s *v1.Secret) bool {
 		cert, ok := s.Data[v1.TLSCertKey]
 		if !ok {
 			m.log.Info("missing TLS certificate", zap.String("secret key", v1.TLSCertKey))
+			m.recorder.NewInvalid(s.GetNamespace(), ingressName, s.GetName())
 			continue
 		}
 		key, ok := s.Data[v1.TLSPrivateKeyKey]
 		if !ok {
 			m.log.Info("missing TLS private key", zap.String("secret key", v1.TLSPrivateKeyKey))
+			m.recorder.NewInvalid(s.GetNamespace(), ingressName, s.GetName())
 			continue
 		}
 

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -9,6 +9,7 @@ import (
 const (
 	eventCertPairWritten = "CertPairWritten"
 	eventCertPairDeleted = "CertPairDeleted"
+	eventCertPairInvalid = "CertPairInvalid"
 )
 
 // A Recorder records events.
@@ -18,6 +19,9 @@ type Recorder interface {
 
 	// NewDelete records the deletion of a certificate pair.
 	NewDelete(namespace, ingressName, secretName string)
+
+	// NewInvalid records an invalid certificate pair.
+	NewInvalid(namespace, ingressName, secretName string)
 }
 
 // A NopRecorder does nothing.
@@ -28,6 +32,9 @@ func (r *NopRecorder) NewWrite(namespace, ingressName, secretName string) {}
 
 // NewDelete does nothing.
 func (r *NopRecorder) NewDelete(namespace, ingressName, secretName string) {}
+
+// NewInvalid does nothing.
+func (r *NopRecorder) NewInvalid(namespace, ingressName, secretName string) {}
 
 // A KubernetesRecorder records events to Kubernetes.
 type KubernetesRecorder struct {
@@ -58,4 +65,14 @@ func (r *KubernetesRecorder) NewDelete(namespace, ingressName, secretName string
 		return
 	}
 	r.e.Eventf(i, v1.EventTypeNormal, eventCertPairDeleted, "Unloaded TLS certificate from secret %s", secretName)
+}
+
+// NewInvalid records an invalid certificate pair as an event on the supplied
+// ingress.
+func (r *KubernetesRecorder) NewInvalid(namespace, ingressName, secretName string) {
+	i, err := r.i.Get(namespace, ingressName)
+	if err != nil {
+		return
+	}
+	r.e.Eventf(i, v1.EventTypeWarning, eventCertPairInvalid, "Could not load invalid TLS certificate from secret %s", secretName)
 }

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -7,9 +7,9 @@ import (
 )
 
 const (
-	eventCertPairWritten = "CertPairWritten"
-	eventCertPairDeleted = "CertPairDeleted"
-	eventCertPairInvalid = "CertPairInvalid"
+	eventCertPairWritten  = "CertPairWritten"
+	eventCertPairDeleted  = "CertPairDeleted"
+	eventTLSSecretInvalid = "TLSSecretInvalid"
 )
 
 // A Recorder records events.
@@ -20,8 +20,8 @@ type Recorder interface {
 	// NewDelete records the deletion of a certificate pair.
 	NewDelete(namespace, ingressName, secretName string)
 
-	// NewInvalid records an invalid certificate pair.
-	NewInvalid(namespace, ingressName, secretName string)
+	// NewInvalidSecret records an invalid TLS secret.
+	NewInvalidSecret(namespace, ingressName, secretName string)
 }
 
 // A NopRecorder does nothing.
@@ -33,8 +33,8 @@ func (r *NopRecorder) NewWrite(namespace, ingressName, secretName string) {}
 // NewDelete does nothing.
 func (r *NopRecorder) NewDelete(namespace, ingressName, secretName string) {}
 
-// NewInvalid does nothing.
-func (r *NopRecorder) NewInvalid(namespace, ingressName, secretName string) {}
+// NewInvalidSecret does nothing.
+func (r *NopRecorder) NewInvalidSecret(namespace, ingressName, secretName string) {}
 
 // A KubernetesRecorder records events to Kubernetes.
 type KubernetesRecorder struct {
@@ -67,12 +67,11 @@ func (r *KubernetesRecorder) NewDelete(namespace, ingressName, secretName string
 	r.e.Eventf(i, v1.EventTypeNormal, eventCertPairDeleted, "Unloaded TLS certificate from secret %s", secretName)
 }
 
-// NewInvalid records an invalid certificate pair as an event on the supplied
-// ingress.
-func (r *KubernetesRecorder) NewInvalid(namespace, ingressName, secretName string) {
+// NewInvalidSecret records an invalid TLS secret as an event on the supplied ingress.
+func (r *KubernetesRecorder) NewInvalidSecret(namespace, ingressName, secretName string) {
 	i, err := r.i.Get(namespace, ingressName)
 	if err != nil {
 		return
 	}
-	r.e.Eventf(i, v1.EventTypeWarning, eventCertPairInvalid, "Could not load invalid TLS certificate from secret %s", secretName)
+	r.e.Eventf(i, v1.EventTypeWarning, eventTLSSecretInvalid, "Could not load TLS certificate from invalid secret %s", secretName)
 }

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -1,0 +1,61 @@
+package event
+
+import (
+	"github.com/negz/hal5d/internal/kubernetes"
+	"k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+)
+
+const (
+	eventCertPairWritten = "CertPairWritten"
+	eventCertPairDeleted = "CertPairDeleted"
+)
+
+// A Recorder records events.
+type Recorder interface {
+	// NewWrite records the writing of a certificate pair.
+	NewWrite(namespace, ingressName, secretName string)
+
+	// NewDelete records the deletion of a certificate pair.
+	NewDelete(namespace, ingressName, secretName string)
+}
+
+// A NopRecorder does nothing.
+type NopRecorder struct{}
+
+// NewWrite does nothing.
+func (r *NopRecorder) NewWrite(namespace, ingressName, secretName string) {}
+
+// NewDelete does nothing.
+func (r *NopRecorder) NewDelete(namespace, ingressName, secretName string) {}
+
+// A KubernetesRecorder records events to Kubernetes.
+type KubernetesRecorder struct {
+	e record.EventRecorder
+	i kubernetes.IngressStore
+}
+
+// NewKubernetesRecorder returns a Recorder that records events to Kubernetes.
+func NewKubernetesRecorder(e record.EventRecorder, i kubernetes.IngressStore) *KubernetesRecorder {
+	return &KubernetesRecorder{e: e, i: i}
+}
+
+// NewWrite records the writing of a certificate pair as an event on the
+// supplied ingress.
+func (r *KubernetesRecorder) NewWrite(namespace, ingressName, secretName string) {
+	i, err := r.i.Get(namespace, ingressName)
+	if err != nil {
+		return
+	}
+	r.e.Eventf(i, v1.EventTypeNormal, eventCertPairWritten, "Loaded TLS certificate from secret %s", secretName)
+}
+
+// NewDelete records the deletion of a certificate pair as an event on the
+// supplied ingress.
+func (r *KubernetesRecorder) NewDelete(namespace, ingressName, secretName string) {
+	i, err := r.i.Get(namespace, ingressName)
+	if err != nil {
+		return
+	}
+	r.e.Eventf(i, v1.EventTypeNormal, eventCertPairDeleted, "Unloaded TLS certificate from secret %s", secretName)
+}

--- a/internal/event/event_test.go
+++ b/internal/event/event_test.go
@@ -1,0 +1,169 @@
+package event
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+)
+
+const (
+	namespace       = "ns"
+	coolIngressName = "coolIngress"
+	coolSecretName  = "coolSecret"
+)
+
+var coolIngress = &v1beta1.Ingress{
+	ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: coolIngressName},
+	Spec:       v1beta1.IngressSpec{TLS: []v1beta1.IngressTLS{{SecretName: coolSecretName}}},
+}
+
+type metadata struct {
+	Namespace string
+	Name      string
+}
+
+type mapIngressStore map[metadata]*v1beta1.Ingress
+
+func (m mapIngressStore) Get(namespace, name string) (*v1beta1.Ingress, error) {
+	md := metadata{Namespace: namespace, Name: name}
+	s, ok := m[md]
+	if !ok {
+		return nil, errors.New("no such ingress")
+	}
+	return s, nil
+}
+
+type event struct {
+	md  metadata
+	t   string
+	r   string
+	msg string
+}
+
+type mapRecorder struct {
+	record.EventRecorder
+	e map[event]bool
+}
+
+func (r *mapRecorder) Eventf(o runtime.Object, eventType, reason, format string, args ...interface{}) {
+	i := o.(*v1beta1.Ingress)
+	r.e[event{
+		metadata{i.GetNamespace(), i.GetName()},
+		eventType,
+		reason,
+		fmt.Sprintf(format, args...),
+	}] = true
+}
+
+func TestNewWrite(t *testing.T) {
+	cases := []struct {
+		name        string
+		i           mapIngressStore
+		ns          string
+		ingressName string
+		secretName  string
+		want        map[event]bool
+	}{
+		{
+			name:        "Success",
+			i:           mapIngressStore{metadata{coolIngress.GetNamespace(), coolIngress.GetName()}: coolIngress},
+			ns:          namespace,
+			ingressName: coolIngressName,
+			secretName:  coolSecretName,
+			want: map[event]bool{
+				{
+					metadata{namespace, coolIngressName},
+					v1.EventTypeNormal,
+					eventCertPairWritten,
+					"Loaded TLS certificate from secret " + coolSecretName,
+				}: true,
+			},
+		},
+		{
+			name:        "IngressNotInStore",
+			i:           mapIngressStore{},
+			ns:          namespace,
+			ingressName: coolIngressName,
+			secretName:  coolSecretName,
+			want:        map[event]bool{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mr := &mapRecorder{e: make(map[event]bool)}
+			r := NewKubernetesRecorder(mr, tc.i)
+			r.NewWrite(tc.ns, tc.ingressName, tc.secretName)
+
+			for e := range tc.want {
+				if !mr.e[e] {
+					t.Errorf("n.NewWrite(%v, %v, %v): want event %#v", tc.ns, tc.ingressName, tc.secretName, e)
+				}
+			}
+			for e := range mr.e {
+				if !tc.want[e] {
+					t.Errorf("n.NewWrite(%v, %v, %v): got unwanted event %#v", tc.ns, tc.ingressName, tc.secretName, e)
+				}
+			}
+		})
+	}
+}
+func TestNewDelete(t *testing.T) {
+	cases := []struct {
+		name        string
+		i           mapIngressStore
+		ns          string
+		ingressName string
+		secretName  string
+		want        map[event]bool
+	}{
+		{
+			name:        "Success",
+			i:           mapIngressStore{metadata{coolIngress.GetNamespace(), coolIngress.GetName()}: coolIngress},
+			ns:          namespace,
+			ingressName: coolIngressName,
+			secretName:  coolSecretName,
+			want: map[event]bool{
+				{
+					metadata{namespace, coolIngressName},
+					v1.EventTypeNormal,
+					eventCertPairDeleted,
+					"Unloaded TLS certificate from secret " + coolSecretName,
+				}: true,
+			},
+		},
+		{
+			name:        "IngressNotInStore",
+			i:           mapIngressStore{},
+			ns:          namespace,
+			ingressName: coolIngressName,
+			secretName:  coolSecretName,
+			want:        map[event]bool{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mr := &mapRecorder{e: make(map[event]bool)}
+			r := NewKubernetesRecorder(mr, tc.i)
+			r.NewDelete(tc.ns, tc.ingressName, tc.secretName)
+
+			for e := range tc.want {
+				if !mr.e[e] {
+					t.Errorf("n.NewDelete(%v, %v, %v): want event %#v", tc.ns, tc.ingressName, tc.secretName, e)
+				}
+			}
+			for e := range mr.e {
+				if !tc.want[e] {
+					t.Errorf("n.NewDelete(%v, %v, %v): got unwanted event %#v", tc.ns, tc.ingressName, tc.secretName, e)
+				}
+			}
+		})
+	}
+}

--- a/internal/event/event_test.go
+++ b/internal/event/event_test.go
@@ -168,7 +168,7 @@ func TestNewDelete(t *testing.T) {
 	}
 }
 
-func TestNewInvalid(t *testing.T) {
+func TestNewInvalidSecret(t *testing.T) {
 	cases := []struct {
 		name        string
 		i           mapIngressStore
@@ -187,8 +187,8 @@ func TestNewInvalid(t *testing.T) {
 				{
 					metadata{namespace, coolIngressName},
 					v1.EventTypeWarning,
-					eventCertPairInvalid,
-					"Could not load invalid TLS certificate from secret " + coolSecretName,
+					eventTLSSecretInvalid,
+					"Could not load TLS certificate from invalid secret " + coolSecretName,
 				}: true,
 			},
 		},
@@ -206,16 +206,16 @@ func TestNewInvalid(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mr := &mapRecorder{e: make(map[event]bool)}
 			r := NewKubernetesRecorder(mr, tc.i)
-			r.NewInvalid(tc.ns, tc.ingressName, tc.secretName)
+			r.NewInvalidSecret(tc.ns, tc.ingressName, tc.secretName)
 
 			for e := range tc.want {
 				if !mr.e[e] {
-					t.Errorf("n.NewInvalid(%v, %v, %v): want event %#v", tc.ns, tc.ingressName, tc.secretName, e)
+					t.Errorf("n.NewInvalidSecret(%v, %v, %v): want event %#v", tc.ns, tc.ingressName, tc.secretName, e)
 				}
 			}
 			for e := range mr.e {
 				if !tc.want[e] {
-					t.Errorf("n.NewInvalid(%v, %v, %v): got unwanted event %#v", tc.ns, tc.ingressName, tc.secretName, e)
+					t.Errorf("n.NewInvalidSecret(%v, %v, %v): got unwanted event %#v", tc.ns, tc.ingressName, tc.secretName, e)
 				}
 			}
 		})

--- a/internal/kubernetes/util.go
+++ b/internal/kubernetes/util.go
@@ -1,0 +1,33 @@
+package kubernetes
+
+import (
+	"k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/client-go/tools/record"
+)
+
+const eventComponent = "hal5d"
+
+// BuildConfigFromFlags is clientcmd.BuildConfigFromFlags with no annoying
+// dependencies on glog.
+// https://godoc.org/k8s.io/client-go/tools/clientcmd#BuildConfigFromFlags
+func BuildConfigFromFlags(apiserver, kubecfg string) (*rest.Config, error) {
+	if kubecfg != "" || apiserver != "" {
+		return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubecfg},
+			&clientcmd.ConfigOverrides{ClusterInfo: api.Cluster{Server: apiserver}}).ClientConfig()
+	}
+	return rest.InClusterConfig()
+}
+
+// NewEventRecorder returns a new record.EventRecorder for the given client.
+func NewEventRecorder(c kubernetes.Interface) record.EventRecorder {
+	b := record.NewBroadcaster()
+	b.StartRecordingToSink(&corev1.EventSinkImpl{Interface: corev1.New(c.CoreV1().RESTClient()).Events("")})
+	return b.NewRecorder(scheme.Scheme, v1.EventSource{Component: eventComponent})
+}


### PR DESCRIPTION
CC @chadcatlett @jacobstr 

Events are emitted to the ingress that loads (or unloads) the certificates. Note that this means events are *not* emitted when the ingress itself is deleted.

```bash
$ kubectl --kubeconfig=$HOME/tfk-negz describe ing nginx
Name:             nginx
Namespace:        default
Address:
Default backend:  default-http-backend:80 (<none>)
TLS:
  nginx terminates
Rules:
  Host                                                Path  Backends
  ----                                                ----  --------
  nginx.ingress.tfk-negz.staging.example.org
                                                         nginx:80 (<none>)
Annotations:
Events:
  Type    Reason           Age   From   Message
  ----    ------           ----  ----   -------
  Normal  CertPairDeleted  4m    hal5d  Unloaded TLS certificate from secret nginx
  Normal  CertPairWritten  25s   hal5d  Loaded TLS certificate from secret nginx
```