### PR TITLE
Differentiate invalid secrets from errors

### DIFF
--- a/cmd/hal5d/hal5d.go
+++ b/cmd/hal5d/hal5d.go
@@ -63,7 +63,7 @@ func main() {
 			prometheus.CounterOpts{
 				Namespace: prometheusNamespace,
 				Name:      "certpair_deletes_total",
-				Help:      "Total certificate pairs deletes from disk.",
+				Help:      "Total certificate pairs deleted from disk.",
 			},
 			[]string{cert.LabelNamespace, cert.LabelIngressName, cert.LabelSecretName},
 		)
@@ -73,7 +73,15 @@ func main() {
 				Name:      "errors_total",
 				Help:      "Total errors encountered while managing certificate pairs.",
 			},
-			[]string{cert.LabelErrorContext},
+			[]string{cert.LabelContext},
+		)
+		invalids = prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: prometheusNamespace,
+				Name:      "invalids_total",
+				Help:      "Total invalid secrets encountered while managing certificate pairs.",
+			},
+			[]string{cert.LabelContext},
 		)
 	)
 	prometheus.MustRegister(writes, deletes, errors)
@@ -85,7 +93,7 @@ func main() {
 	kingpin.FatalIfError(err, "cannot create log")
 	defer log.Sync()
 
-	mx := cert.Metrics{Writes: writes, Deletes: deletes, Errors: errors}
+	mx := cert.Metrics{Writes: writes, Deletes: deletes, Errors: errors, Invalids: invalids}
 
 	c, err := kubernetes.BuildConfigFromFlags(*apiserver, *kubecfg)
 	kingpin.FatalIfError(err, "cannot create Kubernetes client configuration")

--- a/internal/cert/manager_test.go
+++ b/internal/cert/manager_test.go
@@ -2,6 +2,7 @@ package cert
 
 import (
 	"bytes"
+	"fmt"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -48,6 +49,48 @@ var (
 		},
 	}
 )
+
+func TestErr(t *testing.T) {
+	cases := []struct {
+		name   string
+		err    error
+		tester func(error) bool
+		want   bool
+	}{
+		{
+			name:   "FmtIsInvalid",
+			err:    ErrInvalid(fmt.Errorf("kaboom")),
+			tester: IsInvalid,
+			want:   true,
+		},
+		{
+			name:   "ErrorsIsInvalid",
+			err:    ErrInvalid(errors.New("kaboom")),
+			tester: IsInvalid,
+			want:   true,
+		},
+		{
+			name:   "WrappedIsInvalid",
+			err:    errors.Wrap(ErrInvalid(errors.New("kaboom")), "full"),
+			tester: IsInvalid,
+			want:   true,
+		},
+		{
+			name:   "NotInvalid",
+			err:    errors.New("kaboom"),
+			tester: IsInvalid,
+			want:   false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.tester(tc.err)
+			if got != tc.want {
+				t.Errorf("%v: got %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
 
 func TestNewCertPair(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
Previously we treated invalid certificates as an "error" passed up from the write function. This is to an extent the result of poor design - we validate the certificate during the atomic write method before "committing" it.

This PR allows us to signal whether a write failed due to an actual error (i.e. unable to open a file), or because the certificate did not validate (because a clustomer supplied a bad certificate). It also differentiates these two cases in our metrics.